### PR TITLE
Escape illegal whitespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ module.exports = function(req, res, next) {
                //see http://stackoverflow.com/a/4180424/266795
                JSON.stringify(data)
                  .replace(/</g, '\\u003c')
-                 .replace(/-->/g, '--\\>') +
+                 .replace(/-->/g, '--\\>')
+                 .replace(/\u2028/g, '\\u2028')
+                 .replace(/\u2029/g, '\\u2029') +
                ';</script>';
     }
   };

--- a/test.js
+++ b/test.js
@@ -19,14 +19,14 @@ describe('sharify', function() {
       var locals = {};
       sharify.data.escapeHTML = '--></script>';
       sharify({}, { locals: locals }, function(){});
-      locals.sharify.script().should.include('window.__sharifyData = {"escapeHTML":"--\\>\\u003c/script>"};');
+      locals.sharify.script().should.containEql('window.__sharifyData = {"escapeHTML":"--\\>\\u003c/script>"};');
     });
 
     it('returns middleware that adds a sharify script to locals', function() {
       var locals = {};
       sharify.data.foo = 'bar';
       sharify({}, { locals: locals }, function(){});
-      locals.sharify.script().should.include('window.__sharifyData = {"foo":"bar"};');
+      locals.sharify.script().should.containEql('window.__sharifyData = {"foo":"bar"};');
     });
 
     it('exports the data to be required elsewhere', function() {
@@ -42,11 +42,11 @@ describe('sharify', function() {
       sharify.data.foo = 'bar';
       sharify({}, { locals: locals }, function(){});
       locals.sd.location = "NY";
-      locals.sharify.script().should.include('window.__sharifyData = {"foo":"bar","location":"NY"};');
+      locals.sharify.script().should.containEql('window.__sharifyData = {"foo":"bar","location":"NY"};');
 
       locals = {};
       sharify({}, { locals: locals }, function(){});
-      locals.sharify.script().should.include('window.__sharifyData = {"foo":"bar"};');
+      locals.sharify.script().should.containEql('window.__sharifyData = {"foo":"bar"};');
     });
 
     it('does not inject locals data into the constant data', function() {


### PR DESCRIPTION
A description of the issue can be found here: http://webcache.googleusercontent.com/search?q=cache:yOavSvo5LtQJ:timelessrepo.com/json-isnt-a-javascript-subset+&cd=1&hl=en&ct=clnk&gl=us

I'm not entirely sure how to actually write a meaningful spec for this?

(Unrelated, I had to update the include assertion syntax for the latest should.js to get the specs to pass)
